### PR TITLE
Update cache with LastUsed and fix eviction

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -18,23 +18,26 @@ type CacheEntry struct {
 	Coordinate     string          `json:"coordinate"`
 	RetrievedAt    time.Time       `json:"retrieved_at"`
 	LastAccessedAt time.Time       `json:"last_accessed_at"`
+	LastUsed       time.Time       `json:"last_used"`
 	Payload        json.RawMessage `json:"payload"`
 }
 
 type DiskCache struct {
-	dir         string
-	reportTTL   time.Duration
-	unusedTTL   time.Duration
+	dir              string
+	reportTTL        time.Duration
+	unusedTTL        time.Duration
 	refreshThreshold float64
-	mu          sync.Mutex            // guards per-key locking map
-	locks       map[string]*sync.Mutex // per key
+	mu               sync.Mutex             // guards per-key locking map
+	locks            map[string]*sync.Mutex // per key
 }
 
 func NewDiskCache(dir string, reportTTL, unusedTTL time.Duration, refreshThreshold float64) (*DiskCache, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, err
 	}
-	if refreshThreshold <= 0 { refreshThreshold = 0.05 }
+	if refreshThreshold <= 0 {
+		refreshThreshold = 0.05
+	}
 	return &DiskCache{dir: dir, reportTTL: reportTTL, unusedTTL: unusedTTL, refreshThreshold: refreshThreshold, locks: make(map[string]*sync.Mutex)}, nil
 }
 
@@ -60,14 +63,20 @@ func (c *DiskCache) Read(coord string) (*CacheEntry, bool, error) {
 	path := c.keyToPath(coord)
 	f, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) { return nil, false, nil }
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	defer f.Close()
 	b, err := io.ReadAll(f)
-	if err != nil { return nil, false, err }
+	if err != nil {
+		return nil, false, err
+	}
 	var e CacheEntry
-	if err := json.Unmarshal(b, &e); err != nil { return nil, false, err }
+	if err := json.Unmarshal(b, &e); err != nil {
+		return nil, false, err
+	}
 	// update last accessed in memory; caller must call Touch to persist update to avoid heavy writes per read
 	return &e, true, nil
 }
@@ -76,11 +85,49 @@ func (c *DiskCache) Write(e *CacheEntry) error {
 	unlock := c.lockKey(e.Coordinate)
 	defer unlock()
 	path := c.keyToPath(e.Coordinate)
+	if b, err := os.ReadFile(path); err == nil {
+		var prev CacheEntry
+		if json.Unmarshal(b, &prev) == nil {
+			if e.LastUsed.IsZero() {
+				e.LastUsed = prev.LastUsed
+			}
+		}
+	}
 	// atomic write: temp then rename
 	tmp := path + ".tmp"
 	b, err := json.MarshalIndent(e, "", "  ")
-	if err != nil { return err }
-	if err := os.WriteFile(tmp, b, 0o600); err != nil { return err }
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func (c *DiskCache) MarkUsed(coord string, now time.Time) error {
+	unlock := c.lockKey(coord)
+	defer unlock()
+
+	path := c.keyToPath(coord)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var e CacheEntry
+	if err := json.Unmarshal(b, &e); err != nil {
+		return err
+	}
+
+	e.LastUsed = now
+	e.LastAccessedAt = now
+
+	tmp := path + ".tmp"
+	buf, _ := json.MarshalIndent(&e, "", "  ")
+	if err := os.WriteFile(tmp, buf, 0o600); err != nil {
+		return err
+	}
 	return os.Rename(tmp, path)
 }
 
@@ -89,14 +136,22 @@ func (c *DiskCache) Touch(coord string, when time.Time) error {
 	defer unlock()
 	path := c.keyToPath(coord)
 	b, err := os.ReadFile(path)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	var e CacheEntry
-	if err := json.Unmarshal(b, &e); err != nil { return err }
+	if err := json.Unmarshal(b, &e); err != nil {
+		return err
+	}
 	e.LastAccessedAt = when
 	buf, err := json.MarshalIndent(&e, "", "  ")
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, buf, 0o600); err != nil { return err }
+	if err := os.WriteFile(tmp, buf, 0o600); err != nil {
+		return err
+	}
 	return os.Rename(tmp, path)
 }
 
@@ -108,30 +163,46 @@ func (c *DiskCache) IsExpired(e *CacheEntry, now time.Time) bool {
 func (c *DiskCache) Scan(now time.Time) (toRefresh []string, toEvict []string, err error) {
 	entries := []CacheEntry{}
 	err = filepath.WalkDir(c.dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil { return err }
-		if d.IsDir() { return nil }
-		if filepath.Ext(path) != ".json" { return nil }
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
 		b, err := os.ReadFile(path)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 		var e CacheEntry
-		if err := json.Unmarshal(b, &e); err != nil { return err }
+		if err := json.Unmarshal(b, &e); err != nil {
+			return err
+		}
 		entries = append(entries, e)
 		return nil
 	})
-	if err != nil { return nil, nil, err }
+	if err != nil {
+		return nil, nil, err
+	}
 	for _, e := range entries {
 		// eviction: last_accessed older than unusedTTL
-		if e.LastAccessedAt.Add(c.unusedTTL).Before(now) {
+		if e.LastUsed.Add(c.unusedTTL).Before(now) {
 			toEvict = append(toEvict, e.Coordinate)
 			continue
 		}
 		// refresh: below threshold of remaining TTL
 		age := now.Sub(e.RetrievedAt)
-		if age < 0 { age = 0 }
+		if age < 0 {
+			age = 0
+		}
 		if c.reportTTL > 0 {
 			remaining := c.reportTTL - age
 			threshold := c.refreshThreshold
-			if threshold <= 0 { threshold = 0.05 }
+			if threshold <= 0 {
+				threshold = 0.05
+			}
 			if remaining < time.Duration(float64(c.reportTTL)*threshold) {
 				toRefresh = append(toRefresh, e.Coordinate)
 			}

--- a/server.go
+++ b/server.go
@@ -91,7 +91,7 @@ func (s *server) handleComponentReport(w http.ResponseWriter, r *http.Request) {
 		if entry, ok, err := s.cache.Read(c); err == nil && ok {
 			if !s.cache.IsExpired(entry, now) {
 				cacheHits[c] = entry.Payload
-				_ = s.cache.Touch(c, now)
+				_ = s.cache.MarkUsed(c, now)
 			} else {
 				missing = append(missing, c)
 			}
@@ -123,7 +123,7 @@ func (s *server) handleComponentReport(w http.ResponseWriter, r *http.Request) {
 	}
 	// Persist upstream results
 	for coord, payload := range upstreamResults {
-		entry := &CacheEntry{Version: 1, Coordinate: coord, RetrievedAt: now, LastAccessedAt: now, Payload: payload}
+		entry := &CacheEntry{Version: 1, Coordinate: coord, RetrievedAt: now, LastAccessedAt: now, LastUsed: now, Payload: payload}
 		if err := s.cache.Write(entry); err != nil {
 			s.logger.Printf("cache write error coord=%s err=%v", coord, err)
 		}


### PR DESCRIPTION
Fixed cache eviction. Eviction was based on LastAccessedAt which was updated on the maintenance loop refresh meaning eviction would never happen since it uses LastAccessedAt for the expiration math (endless refreshing, no eviction). Added LastUsed, which is a timestamp of last human call. Eviction uses LastUsed for expiration math.